### PR TITLE
feat: Allow "GET /identities/{id}" API to fetch an identity by its credential identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ cover.out
 .idea/
 tmp/
 .DS_Store
-./kratos
+/kratos
 coverage.txt
 packrd/
 *-packr.go
@@ -13,3 +13,4 @@ test/e2e/cypress/videos
 test/e2e/cypress/screenshots
 test/e2e/.bin
 pkged.go
+/.ignored/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Kratos Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+
+      "program": "${workspaceFolder}",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "serve",
+        "--config", ".ignored/config.yml"
+      ]
+    }
+  ]
+}

--- a/identity/pool.go
+++ b/identity/pool.go
@@ -40,6 +40,10 @@ type (
 		// connectivity is broken.
 		GetIdentity(context.Context, uuid.UUID) (*Identity, error)
 
+		// GetIdentityByCredentialsIdentifier returns an identity by querying for it's credential identifiers.
+		// Will return an error if the identity does not exist or backend connectivity is broken.
+		GetIdentityByCredentialsIdentifier(ctx context.Context, match string) (*Identity, error)
+
 		// FindVerifiableAddressByValue returns a matching address or sql.ErrNoRows if no address could be found.
 		FindVerifiableAddressByValue(ctx context.Context, via VerifiableAddressType, address string) (*VerifiableAddress, error)
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

The `GET /identities/{id}` API now accepts [credential identifier](https://www.ory.sh/kratos/docs/concepts/identity-data-model/#identifier-for-username-and-password-flows) (e.g. email address, username, etc.) as the `id` path parameter. Previously, this API only accepts the randomly-generated UUID, making fetching a specific user difficult.
